### PR TITLE
feat(controller): add irsa support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,14 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_iam_role.controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.controller_additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.server_additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [helm_release.argo_application](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_manifest.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [aws_iam_policy_document.controller_irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.server_irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [utils_deep_merge_yaml.argo_helm_values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
 | [utils_deep_merge_yaml.values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
@@ -91,6 +94,8 @@ No modules.
 | <a name="input_argo_project"></a> [argo\_project](#input\_argo\_project) | ArgoCD Application project | `string` | `"default"` | no |
 | <a name="input_argo_spec"></a> [argo\_spec](#input\_argo\_spec) | ArgoCD Application spec configuration. Override or create additional spec parameters | `any` | `{}` | no |
 | <a name="input_argo_sync_policy"></a> [argo\_sync\_policy](#input\_argo\_sync\_policy) | ArgoCD syncPolicy manifest parameter | `any` | `{}` | no |
+| <a name="input_controller_irsa_additional_policies"></a> [controller\_irsa\_additional\_policies](#input\_controller\_irsa\_additional\_policies) | Map of the additional policies to be attached to controller role. Where key is arbitrary id and value is policy arn | `map(string)` | `{}` | no |
+| <a name="input_controller_irsa_role_create"></a> [controller\_irsa\_role\_create](#input\_controller\_irsa\_role\_create) | Whether to create IRSA role and annotate service account for the controller | `bool` | `true` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
 | <a name="input_helm_atomic"></a> [helm\_atomic](#input\_helm\_atomic) | If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used | `bool` | `false` | no |
 | <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"argo-workflows"` | no |
@@ -138,6 +143,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_controller_iam_role_attributes"></a> [controller\_iam\_role\_attributes](#output\_controller\_iam\_role\_attributes) | Argo Workflows controller IAM role attributes |
 | <a name="output_helm_release_application_metadata"></a> [helm\_release\_application\_metadata](#output\_helm\_release\_application\_metadata) | Argo application helm release attributes |
 | <a name="output_helm_release_metadata"></a> [helm\_release\_metadata](#output\_helm\_release\_metadata) | Helm release attributes |
 | <a name="output_kubernetes_application_attributes"></a> [kubernetes\_application\_attributes](#output\_kubernetes\_application\_attributes) | Argo kubernetes manifest attributes |

--- a/iam-controller.tf
+++ b/iam-controller.tf
@@ -1,0 +1,41 @@
+locals {
+  controller_irsa_role_create = var.enabled && var.controller_irsa_role_create
+}
+
+data "aws_iam_policy_document" "controller_irsa" {
+  count = local.controller_irsa_role_create ? 1 : 0
+
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [var.cluster_identity_oidc_issuer_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(var.cluster_identity_oidc_issuer, "https://", "")}:sub"
+
+      values = [
+        "system:serviceaccount:${var.namespace}:${var.service_account_name_prefix}-controller",
+      ]
+    }
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_role" "controller" {
+  count              = local.controller_irsa_role_create ? 1 : 0
+  name               = "${var.irsa_role_name_prefix}-${var.helm_release_name}-controller"
+  assume_role_policy = data.aws_iam_policy_document.controller_irsa[0].json
+  tags               = var.irsa_tags
+}
+
+resource "aws_iam_role_policy_attachment" "controller_additional" {
+  for_each = local.controller_irsa_role_create ? var.controller_irsa_additional_policies : {}
+
+  role       = aws_iam_role.controller[0].name
+  policy_arn = each.value
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,8 @@ output "server_iam_role_attributes" {
   description = "Argo Workflows server IAM role attributes"
   value       = try(aws_iam_role.server[0], {})
 }
+
+output "controller_iam_role_attributes" {
+  description = "Argo Workflows controller IAM role attributes"
+  value       = try(aws_iam_role.controller[0], {})
+}

--- a/values.tf
+++ b/values.tf
@@ -34,6 +34,15 @@ data "utils_deep_merge_yaml" "values" {
         }
       }
     }) : "",
+    local.controller_irsa_role_create ? yamlencode({
+      controller = {
+        serviceAccount = {
+          annotations = {
+            "eks.amazonaws.com/role-arn" = aws_iam_role.controller[0].arn
+          }
+        }
+      }
+    }) : "",
     var.values,
   ])
 }

--- a/variables-controller.tf
+++ b/variables-controller.tf
@@ -1,0 +1,13 @@
+# ================ IRSA variables (optional) ================
+
+variable "controller_irsa_role_create" {
+  type        = bool
+  default     = true
+  description = "Whether to create IRSA role and annotate service account for the controller"
+}
+
+variable "controller_irsa_additional_policies" {
+  type        = map(string)
+  default     = {}
+  description = "Map of the additional policies to be attached to controller role. Where key is arbitrary id and value is policy arn"
+}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

- Add support for controller IRSA. For example, this adds support for the controller to pull images from ECR to determine the image entrypoint/command (https://argo-workflows.readthedocs.io/en/stable/workflow-executors/#image-indexcache). This is also beneficial when the controller runs on an EKS node with limited instance metadata access, i.e. hop count = 1.

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

- I added the IRSA role with the IAM policy, allowing the pulling of images from ECR when the controller is scheduled on a node with hop count = 1. Without IRSA, the controller cannot pull image metadata to determine the image entry point/command.

<!--
Please describe the tests that you ran to verify your changes.
-->
